### PR TITLE
added #include <ctype.h>

### DIFF
--- a/pcsensor.c
+++ b/pcsensor.c
@@ -36,6 +36,7 @@
 #include <string.h>
 #include <errno.h>
 #include <signal.h>
+#include <ctype.h>
 
 
 #define VERSION "1.0.1"


### PR DESCRIPTION
Added include ctype couse when i was compiling on Ubuntu 15.10 version it gave me warning
warning: implicit declaration of function ‘isprint’ [-Wimplicit-function-declaration]
          if (isprint (optopt))

with ctype.h included no warnings, compiles and works
